### PR TITLE
fix+enhancement(controller): Autoupdate fix and backup before update

### DIFF
--- a/files/conanexiles_controller.sh
+++ b/files/conanexiles_controller.sh
@@ -1,56 +1,103 @@
 #!/bin/bash
+APPID=443030
 
-# _current_timestamp=0
-_current_build_id=0
-# _last_timestamp=0
-_last_build_id=0
+function get_available_build() {
+    # get available build id and return it
+    local _build_id=$(/steamcmd/steamcmd.sh +login anonymous +app_info_update 1 +app_info_print $APPID +quit | \
+    			    grep -EA 1000 "^\s+\"branches\"$" | grep -EA 5 "^\s+\"public\"$" | \
+    			    grep -m 1 -EB 10 "^\s+}" | grep -E "^\s+\"buildid\"\s+" | \
+    			    tr '[:blank:]"' ' ' | awk '{print $2}')
 
-start_server() {
+    echo $_build_id
+}
+
+function get_installed_build() {
+    # get currently installed build id and return it
+    local _build_id=$(cat /conanexiles/steamapps/appmanifest_$APPID.acf | \
+              grep -E "^\s+\"buildid\"" |  tr '[:blank:]"' ' ' | awk '{print $2}')
+
+    echo $_build_id
+}
+
+function start_server() {
+    # start the server
     supervisorctl status conanexilesServer | grep RUNNING > /dev/null
     [[ $? != 0 ]] && supervisorctl start conanexilesServer
 }
 
-update_server() {
-
+function stop_server() {
+    # stop the server
     supervisorctl status conanexilesServer | grep RUNNING > /dev/null
     [[ $? == 0 ]] && supervisorctl stop conanexilesServer
+}
 
+function update_server() {
+    # update server  
     supervisorctl status conanexilesUpdate | grep RUNNING > /dev/null
     [[ $? != 0 ]] && supervisorctl start conanexilesUpdate
 }
 
-function do_update() {
-    update_server
-    
-    # wait till update is finished
-    while $(supervisorctl status conanexilesUpdate | grep RUNNING > /dev/null); do
-	sleep 1
-    done
+function backup_server() {
+    # backup the server db and config
+    local _src = "/conanexiles/ConanSandbox/Saved"
+    local _dst = "/conanexiles/ConanSandbox/Saved.$(get_installed_build)"
 
-    # echo $_current_timestamp > /conanexiles/lastUpdate
-    echo $_current_build_id > /conanexiles/lastUpdate
-}
-
-while true; do
-    # _current_timestamp=$(/steamcmd/steamcmd.sh +login anonymous +app_info_update 1 +app_info_print 443030 +quit | \
-    			    # grep -EA 1000 "^\s+\"branches\"$" | grep -EA 5 "^\s+\"public\"$" | \
-    			    # grep -m 1 -EB 10 "^\s+}" | grep -E "^\s+\"timeupdated\"\s+" | \
-    			    # tr '[:blank:]"' ' ' | awk '{print $2}')
-
-    _current_build_id=$(/steamcmd/steamcmd.sh +login anonymous +app_info_update 1 +app_info_print 443030 +quit | \
-    			    grep -EA 1000 "^\s+\"branches\"$" | grep -EA 5 "^\s+\"public\"$" | \
-    			    grep -m 1 -EB 10 "^\s+}" | grep -E "^\s+\"buildid\"\s+" | \
-    			    tr '[:blank:]"' ' ' | awk '{print $2}')
-    
-    # [ -f /conanexiles/lastUpdate ] && _last_timestamp=$(cat /conanexiles/lastUpdate) 
-    [ -f /conanexiles/lastUpdate ] && _last_build_id=$(cat /conanexiles/lastUpdate) 
-
-    # if [[ $_current_timestamp > $_last_timestamp ]];then
-    if [[ $_current_build_id != $_last_build_id ]];then
-	do_update
+    # remove backup dir if already exists (should never happen)
+    if [ -d "$_dst" ]; then
+        rm -rf "$_dst"
+        echo "Info: Removed existing build backup in $_dst"
     fi
 
-    # if initial update fails do this
+    # backup current build db and config
+    if [ -d "$_src" ]; then
+        cp -a "$_src" "$_dst"
+
+        # Was backup successfull ?
+        if [ $? -eq 0 ]; then
+            echo "Info: Backed up current build db and configs to $_dst"
+        else
+            echo "Warning: Failed to backup current build db and configs to $_dst."
+        fi
+    fi
+}
+
+function do_update() {
+    # stop, backup, update and start again the server
+    stop_server
+    backup_server
+    update_server
+    start_server
+        
+    # wait till update is finished
+    while $(supervisorctl status conanexilesUpdate | grep RUNNING > /dev/null); do
+        sleep 1
+    done
+
+    # check if server is up to date
+    local _ab = $(get_available_build)
+    local _ib = $(get_installed_build)
+
+    if [[ $_ab != $_ib ]];then
+        echo "Warning: Update seems to have failed. Installed build ($_ib) does not match available build ($_ab)."
+    else
+        echo "Info: Updated to build ($_ib) successfully."
+    fi
+}
+
+#
+# Main loop
+#
+while true; do
+    # check if an update is needed
+    ab = $(get_available_build)
+    ib = $(get_installed_build)
+
+    if [[ $ab != $ib ]];then
+        echo "Info: New build available. Updating $ib -> $ab"
+        do_update
+    fi
+
+    # if initial install/update fails try again
     [ ! -f "/conanexiles/ConanSandbox/Binaries/Win64/ConanSandboxServer-Win64-Test.exe" ] && do_update
 
     start_server


### PR DESCRIPTION
The reworked a bit how the autoupdate is handled. It should now compare
available build id against the installed build id gathered from steamapps
directory.

Added a function to backup game db and configs before a build change in
case an update breaks the stuff.
Maybe we should do a sqlite check of the backed up db before considering it safe?

*** Warning these changes are not considered valid. Waiting for next update to test it live ***