### PR TITLE
fix(multiple): Reworked the way conan is started through supervisord

### DIFF
--- a/files/conanexiles.conf
+++ b/files/conanexiles.conf
@@ -9,7 +9,7 @@ stdout_logfile_maxbytes=0
 environment = 
     WINEPREFIX=/wine,
     WINEARCH=win64
-command=xvfb-run --auto-servernum --server-args='-screen 0 640x480x24:32' wine64 /conanexiles/ConanSandboxServer.exe -nosteamclient -game -server -log                                                                   
+command=wine64 /conanexiles/ConanSandbox/Binaries/Win64/ConanSandboxServer-Win64-Test.exe -nosteamclient -game -server -log 
 autostart=false                                                                                 
 autorestart=false                                                                               
 stdout_logfile=/dev/stdout                                                                     

--- a/files/conanexiles_controller.sh
+++ b/files/conanexiles_controller.sh
@@ -23,6 +23,12 @@ function get_installed_build() {
 }
 
 function start_server() {
+    # check if server is already running to avoid running it more than one time
+    if ps axg | grep -F 'ConanSandboxServer' | grep -v -F 'grep' > /dev/null; then
+        echo "Error: The server is already running. I don't want to start it twice."
+        return
+    fi
+
     # start the server
     supervisorctl status conanexilesServer | grep RUNNING > /dev/null
     [[ $? != 0 ]] && supervisorctl start conanexilesServer
@@ -32,6 +38,12 @@ function stop_server() {
     # stop the server
     supervisorctl status conanexilesServer | grep RUNNING > /dev/null
     [[ $? == 0 ]] && supervisorctl stop conanexilesServer
+
+    # wait until the server process is gone
+    while ps axg | grep -F 'ConanSandboxServer' | grep -v -F 'grep' > /dev/null; do 
+      echo "Error: Seems I can't stop the server. Help me!"
+      sleep 5
+    done
 }
 
 function update_server() {

--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -248,5 +248,11 @@ setup_server_config_first_time
 
 override_config
 
+# start Xvfb
+xvfb_display=0
+rm -rf /tmp/.X$xvfb_display-lock
+Xvfb :$xvfb_display -screen 0, 640x480x24:32 -nolisten tcp &
+export DISPLAY=:$xvfb_display
+
 # start supervisord
 "$@"


### PR DESCRIPTION
I've noticed that stopping conan through supervisord does nothing.
After a few searches I found out it's related with how the previously used xvfb-run tool works.
It will just fork a Xvfb process that is detached from xvbd-run.

Per nature supervisord uses signals sent to the process it started to stop it. It will then not work in that case.
That why I reworked the things so that supervisord directly call wine64 to open the Conan Exiles executable.
So when we ask supervisord to stop the process it will kill TERM this one and hopefully really stop it.

Also now Xvfb is started once for all and sent to background at container boot and not from supervisord anymore.
I also added checks in the controller bash script to check that server has been successfully stopped (for server_stop) and that it's not already running (for server_start).

I hope these changes will work around what can go wrong when an update is available :)