### PR TITLE
fixed wrong docker-compose examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ version: "3.5"
 
 services:
   ce0:
-    build: src/
     image: alinmear/docker-conanexiles:latest
-    depends_on: redis
+    depends_on: 
+      - redis
     restart: unless-stopped
     environment:
       - "CONANEXILES_ServerSettings_ServerSettings_AdminPassword=ThanksForThisSmartSolution"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ version: "3.5"
 
 services:
   ce0:
-    build: src/
     image: alinmear/docker-conanexiles:latest
     depends_on:
       - redis


### PR DESCRIPTION
 - build can be not there, when you only use the yml
 - depends_on has to be an array