### PR TITLE
Fixed missing "\" in Dockerfile

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -30,7 +30,7 @@ ADD https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetrick
 RUN chmod +x /usr/bin/winetricks
 
 RUN apt-get update \
-    && apt-get install -y x11vnc strace cabextract
+    && apt-get install -y x11vnc strace cabextract \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
Just a simple missing slash required to escape the newline