### PR TITLE
Fixed mods.txt containing windows newline

### DIFF
--- a/src/usr/bin/conanexiles_controller
+++ b/src/usr/bin/conanexiles_controller
@@ -193,6 +193,8 @@ start_master_loop() {
             echo > /conanexiles/steamapps/workshop/content/$APPID_Mods/modlist.txt
             for modid in $(cat /conanexiles/ConanSandbox/Mods/mods.txt) ; do
                 notifier_info "Found mod $modid"
+                #Strip the carriage return used as a newline in some windows text editors
+                modid=$(echo $modid|tr -d '\r')
                 if [ -d /conanexiles/steamapps/workshop/content/$APPID_Mods/$modid ] ; then
                     for filename in $(cd /conanexiles/steamapps/workshop/content/$APPID_Mods/$modid && find -name "*.pak") ; do
                         filename="$(basename "$filename")"


### PR DESCRIPTION
If mods.txt was manually created on windows or edited with a windows text editor, it may contain the windows newline \r\n instead of just the Unix newline \n. This will cause the generation of modlist.txt to fail as there will be an extra \r at the end of the folder name. 
That means the mod directory check will always return false:
```
[ -d /conanexiles/steamapps/workshop/content/$APPID_Mods/$modid ]
```
And changing to the mod directory always return that the directory is nonexistent:
```
cd /conanexiles/steamapps/workshop/content/$APPID_Mods/$modid
```

This fix strips the carriage return (\r) from the $modid string so that the string only contains the mod's ID.